### PR TITLE
Terraria Server scripts

### DIFF
--- a/Terraria/Backup_Terraria_World.ps1
+++ b/Terraria/Backup_Terraria_World.ps1
@@ -1,0 +1,49 @@
+# ------------------------------------------------------------------------------
+# Script  : Backup_Terraria_World.ps1
+# Author  : Robert (Rob) Waight
+# Date    : 3/24/2020
+# Version : 0.1
+# Keywords: Terraria Server, TShock Terraria Server, Terraria World Backups
+# Comments: Create a backup of a specified Terraria world with a different
+#             extension than `.wld.bak` and including a date/timestamp.
+#             This script is helpful when your kids are home from school and you
+#             need to create a point-in-time backup of the Terraria world.
+#             
+#             This script should be run as a scheduled task on an interval.
+#
+# Command line options: https://tshock.readme.io/docs/command-line-parameters
+# ------------------------------------------------------------------------------
+
+$terrariaWorlds="T:\Path\To\Terraria\Worlds"
+$targetWorld="myWorld"
+$backupExt=".myBackups"
+
+# Write to the Windows Application log
+$LogSource="Terraria_World_Backup"
+New-EventLog -LogName Application -Source $LogSource
+
+# Event Log function
+function EventLog($String, $EventID, $Color){
+    if ($Color -eq $null) {$Color = "white"}
+    Write-Host $String -ForegroundColor $Color
+    Write-EventLog Application -Source $LogSource -EventID $EventID -Message $String
+}
+
+EventLog "Starting Backup_Terraria_Worlds.ps1 at $(get-date)" 1
+$worldBackup=$terrariaWorlds+"\"+$targetWorld+".wld.bak"
+$targetLatest=$terrariaWorlds+"\"+$targetWorld+".wld.*"+$backupExt
+$latestBackup=Get-ChildItem -Path $targetLatest | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$latestName=$latestBackup.name
+EventLog "The latest backup is: $latestName" 1
+
+if(Compare-Object -ReferenceObject $(Get-Content $worldBackup) -DifferenceObject $(Get-Content $latestBackup))
+  {
+    EventLog "Creating a new backup file!" 3 Yellow
+    EventLog "The current backup file is different from: $latestName" 3 Yellow
+    $newBackup=$terrariaWorlds+"\"+$targetWorld+".wld."+$(Get-Date -format 'yyyyMMdd-HHmm')+$backupExt
+    Copy-Item $worldBackup -Destination $newBackup
+    EventLog "Copied the current world backup to: $newBackup" 3 Yellow
+  }
+  else{EventLog "The current backup file is the same as $latestName" 2 Yellow}
+
+EventLog "Finished Backup_Terraria_Worlds.ps1 at $(get-date)" 1

--- a/Terraria/README.md
+++ b/Terraria/README.md
@@ -1,0 +1,10 @@
+PowerShell scripts to start, audit, and backup Terraria while kids are home from school.
+
+#### `Start_TerrariaServer.ps1`
+Used to start TShock Terraria Server with a modified logpath
+
+#### `Start_TerrariaServer_2ndInstance.ps1`
+Used to start a second instance of TShock Terraria Server with a modified logpath
+
+#### `Backup_Terraria_World.ps1`
+Create a point-in-time backup of a specified Terraria world with a different extension than .wld.bak and including a date/timestamp.

--- a/Terraria/Start_TerrariaServer.ps1
+++ b/Terraria/Start_TerrariaServer.ps1
@@ -1,0 +1,37 @@
+# ------------------------------------------------------------------------------
+# Script  : Start_TerrariaServer.ps1
+# Author  : Robert (Rob) Waight
+# Date    : 3/24/2020
+# Version : 1.1
+# Keywords: Terraria Server, TShock Terraria Server
+# Comments: Start T-Shock 4.3.26 with a modified logpath directory.  No other
+#             command line options are issued.  Using a separate logpath is
+#             helpful to retain logs when users restart the Terraria server
+#
+# Command line options: https://tshock.readme.io/docs/command-line-parameters
+# ------------------------------------------------------------------------------
+
+$tshockServer="T:\Path\To\TerrariaServer"
+$tshockVersion="4.3.26"
+cd $tshockServer
+
+# Create the directory for the transcript, if it does not exist
+if(-not(Test-Path -path "$tshockServer\logs"))
+  {
+    Write-Host -ForegroundColor Yellow "The log directory $tshockServer\logs has not been found."
+    New-Item -ItemType Directory -Path "$tshockServer\logs" -Confirm
+  }
+
+Start-Transcript .\logs\run_terraria-server_$(Get-Date -format 'yyyyMMdd-HHmmss').log
+cd ".\tshock_$tshockVersion"
+
+# Create the directory for the server logs, if it does not exist
+if(-not(Test-Path -path "$tshockServer\tshock_$tshockVersion\serverLogs"))
+  {
+    Write-Host -ForegroundColor Yellow "The log directory $tshockServer\tshock_$tshockVersion\serverLogs has not been found."
+    New-Item -ItemType Directory -Path "$tshockServer\tshock_$tshockVersion\serverLogs" -Confirm
+  }
+
+# Start TShock Terraria Server with a modified logpath directory
+Write-Host "Command line options are available at: https://tshock.readme.io/docs/command-line-parameters"
+.\TerrariaServer.exe -logpath .\serverLogs\

--- a/Terraria/Start_TerrariaServer_2ndInstance.ps1
+++ b/Terraria/Start_TerrariaServer_2ndInstance.ps1
@@ -1,0 +1,42 @@
+# ------------------------------------------------------------------------------
+# Script  : Start_TerrariaServer_2ndInstance.ps1
+# Author  : Robert (Rob) Waight
+# Date    : 3/24/2020
+# Version : 1.1
+# Keywords: Terraria Server, TShock Terraria Server
+# Comments: Start a second instance of T-Shock 4.3.26 with a modified logpath
+#             directory.  No other command line options are issued.  The second 
+#             instance is helpful when your kids are home from school and you
+#             need to run multiple instances of the server.  Using a separate
+#             logpath is helpful to retain logs when users restart the Terraria
+#             server while their sibling is playing
+#
+# Command line options: https://tshock.readme.io/docs/command-line-parameters
+# ------------------------------------------------------------------------------
+
+$tshockServer="T:\Path\To\TerrariaServer"
+$tshockVersion="4.3.26"
+$tshockAltPort="10000"
+$tshockVersion=$tshockVersion+"_instance2"
+cd $tshockServer
+
+# Create the directory for the transcript, if it does not exist
+if(-not(Test-Path -path "$tshockServer\logs"))
+  {
+    Write-Host -ForegroundColor Yellow "The log directory $tshockServer\logs has not been found."
+    New-Item -ItemType Directory -Path "$tshockServer\logs" -Confirm
+  }
+
+Start-Transcript .\logs\run_terraria-server_2nd-instance_$(Get-Date -format 'yyyyMMdd-HHmmss').log
+cd ".\tshock_$tshockVersion"
+
+# Create the directory for the server logs, if it does not exist
+if(-not(Test-Path -path "$tshockServer\tshock_$tshockVersion\serverLogs"))
+  {
+    Write-Host -ForegroundColor Yellow "The log directory $tshockServer\tshock_$tshockVersion\serverLogs has not been found."
+    New-Item -ItemType Directory -Path "$tshockServer\tshock_$tshockVersion\serverLogs" -Confirm
+  }
+
+# Start TShock Terraria Server with a modified logpath directory
+Write-Host "Command line options are available at: https://tshock.readme.io/docs/command-line-parameters"
+.\TerrariaServer.exe -logpath .\serverLogs\ -port $tshockAltPort


### PR DESCRIPTION
Scripts to start, audit, and backup Terraria while kids are home from school.
1. Create `Start_TerrariaServer.ps1` - Used to start TShock Terraria Server with a modified logpath
2. Create `Start_TerrariaServer_2ndInstance.ps1` - Used to start a second instance of TShock Terraria Server with a modified logpath
3. Create `Backup_Terraria_World.ps1` - Create a point-in-time backup of a specified Terraria world with a different extension than `.wld.bak` and including a date/timestamp.
4. Create `Terraria\README.md`